### PR TITLE
Compilation fixes (ubuntu 20.04, gcc 9.3.0)

### DIFF
--- a/bu/CMakeLists.txt
+++ b/bu/CMakeLists.txt
@@ -1,14 +1,20 @@
 cmake_minimum_required(VERSION 3.5)
 project(EPF VERSION 1.0 LANGUAGES CXX)
 
-find_package(Pdal REQUIRED)
+find_package(PDAL REQUIRED)
+if(PDAL_VERSION_MAJOR LESS 2)
+  message(FATAL_ERROR "PDAL version is too old (${PDAL_VERSION}). Use 2.2 or higher.")
+endif()
+if((PDAL_VERSION_MAJOR EQUAL 2) AND (PDAL_VERSION_MINOR LESS 2))
+  message(FATAL_ERROR "PDAL version is too old (${PDAL_VERSION}). Use 2.2 or higher.")
+endif()
 
 file(GLOB SRCS *.cpp)
 
 add_executable(bu ${SRCS})
 
 target_include_directories(bu PRIVATE ${PDAL_INCLUDE_DIRS})
-target_link_libraries(bu PRIVATE ${PDAL_LIBRARIES})
+target_link_libraries(bu PRIVATE ${PDAL_LIBRARIES} pthread)
 
 set_property(TARGET bu PROPERTY CXX_STANDARD 11)
 set_property(TARGET bu PROPERTY CXX_STANDARD_REQUIRED TRUE)

--- a/common/GridKey.hpp
+++ b/common/GridKey.hpp
@@ -13,6 +13,10 @@
 
 #pragma once
 
+#include <cassert>
+#include <climits>
+#include <iostream>
+
 namespace ept2
 {
 

--- a/epf/CMakeLists.txt
+++ b/epf/CMakeLists.txt
@@ -1,14 +1,20 @@
 cmake_minimum_required(VERSION 3.5)
 project(EPF VERSION 1.0 LANGUAGES CXX)
 
-find_package(Pdal REQUIRED)
+find_package(PDAL REQUIRED)
+if(PDAL_VERSION_MAJOR LESS 2)
+  message(FATAL_ERROR "PDAL version is too old (${PDAL_VERSION}). Use 2.2 or higher.")
+endif()
+if((PDAL_VERSION_MAJOR EQUAL 2) AND (PDAL_VERSION_MINOR LESS 2))
+  message(FATAL_ERROR "PDAL version is too old (${PDAL_VERSION}). Use 2.2 or higher.")
+endif()
 
 file(GLOB SRCS *.cpp)
 
 add_executable(epf ${SRCS})
 
 target_include_directories(epf PRIVATE ${PDAL_INCLUDE_DIRS})
-target_link_libraries(epf PRIVATE ${PDAL_LIBRARIES})
+target_link_libraries(epf PRIVATE ${PDAL_LIBRARIES} pthread)
 
 set_property(TARGET epf PROPERTY CXX_STANDARD 11)
 set_property(TARGET epf PROPERTY CXX_STANDARD_REQUIRED TRUE)


### PR DESCRIPTION
- cmake: find PDAL not Pdal (otherwise PDALConfig.cmake is not used)
- cmake: add pdal version check (>= 2.2 because of ThreadPool include)
- missing #includes
- missing link to pthreads