### PR TITLE
Add install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,3 +34,5 @@ target_link_libraries(untwine
 
 set_property(TARGET untwine PROPERTY CXX_STANDARD 11)
 set_property(TARGET untwine PROPERTY CXX_STANDARD_REQUIRED TRUE)
+
+install(TARGETS untwine DESTINATION bin)


### PR DESCRIPTION
Hey all :wave: 

noticed that the CMakeLists is missing an install target. This can be useful for people who build untwine and want to install it permanently via `make install`.