### PR TITLE
Fix compilation on Ubuntu 20.04

### DIFF
--- a/api/QgisUntwine_unix.cpp
+++ b/api/QgisUntwine_unix.cpp
@@ -4,6 +4,7 @@
 #include <signal.h>
 #include <unistd.h>
 #include <sys/errno.h>
+#include <sys/wait.h>
 
 #include "QgisUntwine.hpp"
 


### PR DESCRIPTION
Fixes the compilation error:

```
/usr/bin/c++    -Wno-implicit-fallthrough -Wno-int-in-bool-context -Wno-dangling-else -Wno-noexcept-type -Wall -Wextra -Wpointer-arith -Wcast-align -Wcast-qual -Wno-error=parentheses -Wno-error=cast-qual -Wredundant-decls -Wno-unused-parameter -Wno-unused-variable -Wno-long-long -Wno-unknown-pragmas -Wno-deprecated-declarations -Werror -std=gnu++11 -MD -MT CMakeFiles/qgt.dir/QgisUntwine.cpp.o -MF CMakeFiles/qgt.dir/QgisUntwine.cpp.o.d -o CMakeFiles/qgt.dir/QgisUntwine.cpp.o -c ../QgisUntwine.cpp
In file included from ../QgisUntwine.cpp:8:
../QgisUntwine_unix.cpp: In member function ‘bool untwine::QgisUntwine::stop()’:
../QgisUntwine_unix.cpp:66:11: error: ‘waitpid’ was not declared in this scope
   66 |     (void)waitpid(m_pid, nullptr, 0);
      |           ^~~~~~~
../QgisUntwine_unix.cpp: In member function ‘bool untwine::QgisUntwine::running()’:
../QgisUntwine_unix.cpp:79:25: error: ‘::waitpid’ has not been declared
   79 |     if (m_running && (::waitpid(m_pid, nullptr, WNOHANG) != 0))
      |                         ^~~~~~~
```