### PR TITLE
Fix compilation on Windows

### DIFF
--- a/epf/FileProcessor.cpp
+++ b/epf/FileProcessor.cpp
@@ -50,7 +50,7 @@ void FileProcessor::run()
     // This is some random cell that ultimately won't get used, but it contains a buffer
     // into which we can write data.
     Cell *cell = m_cellMgr.get(VoxelKey());
-    f.setCallback([this, &count, &limit, &cell](pdal::PointRef& point)
+    f.setCallback([this, &count, &limit, &cell, CountIncrement](pdal::PointRef& point)
         {
             // Write the data into the point buffer in the cell.  This is the *last*
             // cell buffer that we used. We're hoping that it's the right one.

--- a/untwine/MapFile.hpp
+++ b/untwine/MapFile.hpp
@@ -30,10 +30,12 @@
 
 #pragma once
 
+#include <fcntl.h>
+
 #ifdef _WIN32
 #include <Windows.h>
+#include <io.h>
 #else
-#include <fcntl.h>
 #include <unistd.h>
 #include <sys/mman.h>
 #endif


### PR DESCRIPTION
Hello :hand:

Trying to compile Untwine on Windows (Windows 10, Visual Studio 2019) I get the following:

```
  Untwine.cpp
D:\ddb\untwine\untwine\MapFile.cpp(50,18): error C2039: '_open': is not a member of '`global namespace'' [D:\ddb\untwin
e\build\untwine.vcxproj]
D:\ddb\untwine\untwine\MapFile.cpp(50,53): error C2065: '_O_RDONLY': undeclared identifier [D:\ddb\untwine\build\untwin
e.vcxproj]
D:\ddb\untwine\untwine\MapFile.cpp(50,65): error C2065: '_O_RDWR': undeclared identifier [D:\ddb\untwine\build\untwine.
vcxproj]
D:\ddb\untwine\untwine\MapFile.cpp(50,23): error C3861: '_open': identifier not found [D:\ddb\untwine\build\untwine.vcx
proj]
D:\ddb\untwine\untwine\MapFile.cpp(68,46): error C3861: '_get_osfhandle': identifier not found [D:\ddb\untwine\build\un
twine.vcxproj]
D:\ddb\untwine\untwine\MapFile.cpp(103,7): error C2039: '_close': is not a member of '`global namespace'' [D:\ddb\untwi
ne\build\untwine.vcxproj]
D:\ddb\untwine\untwine\MapFile.cpp(103,13): error C3861: '_close': identifier not found [D:\ddb\untwine\build\untwine.v
cxproj]
D:\ddb\untwine\epf\FileProcessor.cpp(77,1): error C3493: 'CountIncrement' cannot be implicitly captured because no defa
ult capture mode has been specified [D:\ddb\untwine\build\untwine.vcxproj]
```

So I did the following:

- [x] Include `fcntl.h` and `io.h` which on Windows provide the functions / constants being reported as missing.
- [x] Set a capture mode for CountIncrement.

Let me know if changes are needed.