### PR TITLE
add #include <algorithm> to QgisUntwine_win.cpp

### DIFF
--- a/api/QgisUntwine_win.cpp
+++ b/api/QgisUntwine_win.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <algorithm>
 
 #include "QgisUntwine.hpp"
 


### PR DESCRIPTION
`QgisUntwine_win.cpp` uses `std::min` which is defined in `<algorithm>` which isn't currently included. On Visual Studio 2017 (and I suspect other versions...) this results in a compile error.

xref: https://github.com/conda-forge/qgis-feedstock/pull/178