### PR TITLE
Syntax fix in writer

### DIFF
--- a/epf/Writer.hpp
+++ b/epf/Writer.hpp
@@ -48,7 +48,7 @@ namespace epf
 // Since processors try to hold onto buffers until they are full, there can be times at
 // which the buffers are exhaused and no more are available, but none are ready to be
 // written. In this case, the buffers for the processor needing a new buffer flushed to
-/  the queue even if they aren't full so that they can be reused. The active buffer for a
+// the queue even if they aren't full so that they can be reused. The active buffer for a
 // flushing processor is reserved, so there need to be at least one more buffer than the
 // number of file processors, though typically there are many more buffers than file processors.
 //


### PR DESCRIPTION
Fixes obvious syntax error, bug was introduced in be5a3920

```
$ cc --version
Apple clang version 13.0.0 (clang-1300.0.29.3)
Target: x86_64-apple-darwin20.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

$ make
...
In file included from /Users/rcoup/code/untwine/epf/Cell.cpp:15:
/Users/rcoup/code/untwine/epf/Writer.hpp:51:1: error: expected unqualified-id
/  the queue even if they aren't full so that they can be reused. The active buffer for a
^
/Users/rcoup/code/untwine/epf/Writer.hpp:51:31: error: missing terminating ' character [-Werror,-Winvalid-pp-token]
/  the queue even if they aren't full so that they can be reused. The active buffer for a
                              ^
/Users/rcoup/code/untwine/epf/Cell.cpp:24:21: error: member access into incomplete type 'untwine::epf::Writer'
    m_buf = m_writer->fetchBuffer();
                    ^
/Users/rcoup/code/untwine/epf/Cell.hpp:31:7: note: forward declaration of 'untwine::epf::Writer'
class Writer;
      ^
/Users/rcoup/code/untwine/epf/Cell.cpp:31:25: error: member access into incomplete type 'untwine::epf::Writer'
        m_buf = m_writer->fetchBufferBlocking();
                        ^
/Users/rcoup/code/untwine/epf/Cell.hpp:31:7: note: forward declaration of 'untwine::epf::Writer'
class Writer;
      ^
/Users/rcoup/code/untwine/epf/Cell.cpp:43:17: error: member access into incomplete type 'untwine::epf::Writer'
        m_writer->enqueue(m_key, std::move(m_buf), size);
                ^
/Users/rcoup/code/untwine/epf/Cell.hpp:31:7: note: forward declaration of 'untwine::epf::Writer'
class Writer;
      ^
/Users/rcoup/code/untwine/epf/Cell.cpp:45:17: error: member access into incomplete type 'untwine::epf::Writer'
        m_writer->replace(std::move(m_buf));
                ^
/Users/rcoup/code/untwine/epf/Cell.hpp:31:7: note: forward declaration of 'untwine::epf::Writer'
class Writer;
      ^
6 errors generated.
...
```