### PR TITLE
Require laz-perf 3.0.0 to build untwine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if ((PDAL_VERSION_MAJOR EQUAL 1) AND (PDAL_VERSION_MINOR LESS 7))
   message(FATAL_ERROR "PDAL version is too old (${PDAL_VERSION}). Use 1.7 or higher.")
 endif()
 
-find_package(Lazperf REQUIRED 2.1.0)
+find_package(Lazperf REQUIRED 3.0.0)
 find_package(Threads)
 set_package_properties(Threads PROPERTIES DESCRIPTION
     "The thread library of the system" TYPE REQUIRED)


### PR DESCRIPTION
I had laz-perf 2.1.0 but untwine from the main branch failed to compile with various build errors, so I guess 3.0.0 is the required minimum now (which compiles fine with latest untwine).

An excerpt from compile errors with laz-perf 2.1.0:
```
../bu/CopcSupport.hpp:57:14: error: ‘copc_info_vlr’ in namespace ‘lazperf’ does not name a type; did you mean ‘copc_vlr’?
```