### PR TITLE
add missing header to compile QGIS

### DIFF
--- a/api/QgisUntwine.cpp
+++ b/api/QgisUntwine.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <iostream>
 
 #include "QgisUntwine.hpp"


### PR DESCRIPTION
Without the header for `cstdint`, QGIS fails to build in fedora. See https://github.com/qgis/QGIS/pull/52464