### PR TITLE
Add a --threads option to make the number of worker threads configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ Options
   Only read 'file_limit' input files even if more exist in the 'files' list. Used primarily
   for debugging. [Default: no limit]
 
+- `--threads`
+
+  Number of worker threads used for tiling and sampling. Memory use scales with the thread
+  count. [Default: 0, meaning the number of hardware threads]
+
 - `--stats`
 
   Generate summary statistics in 'ept.json' similar to those produced by Entwine for EPT output

--- a/bu/PyramidManager.cpp
+++ b/bu/PyramidManager.cpp
@@ -28,8 +28,8 @@ namespace untwine
 namespace bu
 {
 
-PyramidManager::PyramidManager(const BaseInfo& b) : m_b(b), m_pool(10), m_totalPoints(0),
-    m_copc(m_b)
+PyramidManager::PyramidManager(const BaseInfo& b) : m_b(b), m_pool(m_b.opts.numThreads),
+    m_totalPoints(0), m_copc(m_b)
 {}
 
 PyramidManager::~PyramidManager()

--- a/epf/Epf.cpp
+++ b/epf/Epf.cpp
@@ -25,7 +25,7 @@ namespace epf
 static_assert(MaxBuffers > NumFileProcessors, "MaxBuffers must be greater than NumFileProcessors.");
 Epf::Epf(BaseInfo& common) :
     m_b(common), m_grid(m_b.bounds, m_b.numPoints, m_b.opts.level, m_b.opts.doCube),
-    m_pool(NumFileProcessors)
+    m_pool(m_b.opts.numThreads)
 {}
 
 Epf::~Epf()

--- a/untwine/Common.hpp
+++ b/untwine/Common.hpp
@@ -30,6 +30,8 @@ struct Options
     bool doCube;
     size_t fileLimit;
     int level;
+    // Worker threads. Resolved to a positive value by handleOptions().
+    int numThreads {0};
     int progressFd;
     bool progressDebug;
     StringList dimNames;

--- a/untwine/Untwine.cpp
+++ b/untwine/Untwine.cpp
@@ -15,6 +15,7 @@
 #include <pdal/util/ProgramArgs.hpp>
 
 #include <regex>
+#include <thread>
 
 #include "Common.hpp"
 #include "Config.hpp"
@@ -31,6 +32,9 @@
 namespace untwine
 {
 
+// Must stay below epf::MaxBuffers so a processor can always claim a buffer.
+const int MaxThreads = 512;
+
 void addArgs(pdal::ProgramArgs& programArgs, Options& options, pdal::Arg * &tempArg)
 {
     programArgs.add("output_dir,o", "Output filename", options.outputName).setPositional();
@@ -43,6 +47,8 @@ void addArgs(pdal::ProgramArgs& programArgs, Options& options, pdal::Arg * &temp
         options.level, -1);
     programArgs.add("file_limit", "Only load 'file_limit' files, even if more exist",
         options.fileLimit, (size_t)10000000);
+    programArgs.add("threads", "Number of worker threads to use. 0 uses the number of "
+        "hardware threads available.", options.numThreads, 0);
     programArgs.add("progress_fd", "File descriptor on which to write progress messages.",
         options.progressFd, -1);
     programArgs.add("progress_debug", "Send progress info to stdout.", options.progressDebug);
@@ -98,6 +104,15 @@ bool handleOptions(pdal::StringList& arglist, Options& options)
             options.tempDir = options.outputName + "_tmp";
         }
         options.stats = true;
+
+        // 0 means "use the hardware concurrency". The pools take an unsigned count, so a
+        // non-positive value must never escape here.
+        if (options.numThreads <= 0)
+            options.numThreads = (int)std::thread::hardware_concurrency();
+        if (options.numThreads <= 0)
+            options.numThreads = 8;
+        if (options.numThreads > MaxThreads)
+            options.numThreads = MaxThreads;
 
         if (options.progressFd == 1 && options.progressDebug)
         {


### PR DESCRIPTION
Closes #121.

Untwine's thread counts are compile-time constants: 8 file processors (`epf/EpfTypes.hpp`)
and 10 build-up threads (`bu/PyramidManager.cpp`). On bigger machines most cores sit idle.

This adds `--threads N`, defaulting to the hardware thread count, and sizes both pools from
it. That is the whole change: 25 added lines across 5 files, and the only existing logic
touched is the two pool constructors. Writer threads and the buffer pool stay fixed —
scaling them with the thread count measured no speedup, only more memory.

The value is clamped to 512. That keeps `MaxBuffers > threads`, so a flushing file processor
can always claim a buffer, and avoids an abort in `ThreadPool` when asking for more threads
than the OS can create.

## Results

Ryzen 9 9900X (12 cores / 24 threads, NVMe), `-O3`, against upstream 532bca4. AHN5 rows
are medians of 3 interleaved runs, the other two single runs:

| dataset | points | upstream | `--threads 24` |
| --- | --- | --- | --- |
| AHN5 tile | 29 M | 6.2 s | 5.3 s (1.18x) |
| AHN5, 5 tiles | 139 M | 25.7 s | 20.0 s (1.28x) |
| melbourne-2018 | 354 M | 71.5 s | 51.0 s (1.40x) |
| boston-lot-2021 | 1.75 B | 406.5 s | 293.2 s (1.39x) |

melbourne and boston-lot are the public COPC datasets from pointcloud.org. The speedup
levels off near 1.4x because the build-up phase serialises toward the root of the tree.
Peak RSS roughly doubles: 1.0 GB → 2.2 GB on boston-lot at 24 threads.

Output was validated with `copc-validator --deep` and by comparing input and output as
point multisets (XYZ, intensity, returns, classification, GPS time, RGB) — identical to
upstream at `--threads 8`, `24` and `48`, single- and multi-file.

## Notes for review

- The default changes: untwine now uses all hardware threads, with the memory cost above.
  Happy to keep the old fixed counts as the default and make this opt-in if preferred.
- `--threads 8` is not exactly upstream (upstream runs 10 build-up threads); `--threads 10`
  matches it.
- `NumFileProcessors` still feeds the flush heuristic in `Writer::fetchBuffer()`. Plumbing
  the real thread count through measured no difference, so it is left untouched.
