### PR TITLE
Fix test link failure when the environment ships a different googletest

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,10 @@ option(gtest_force_shared_crt "Always use shared Visual C++ run-time DLL" ON)
 
 add_subdirectory(gtest)
 
+# Keep vendored gtest on the -I path so a stray system gtest can't shadow it.
+set_target_properties(gtest gtest_main PROPERTIES
+    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "")
+
 ###############################################################################
 # Add a test target.
 # _name The driver name.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,11 +26,13 @@ macro(UNTWINE_ADD_TEST _name)
         ${LAZPERF_SRCS}
     )
     untwine_target_compile_settings(${_name})
+    # Vendored gtest must precede external include dirs (PDAL_INCLUDE_DIRS is
+    # the whole install prefix, which may contain a different gtest version).
     target_include_directories(${_name} PRIVATE
+        gtest/include
         ${PROJECT_SOURCE_DIR}
         ${PDAL_INCLUDE_DIRS}
         ${CMAKE_CURRENT_BINARY_DIR}
-        gtest/include
     )
     set_property(TARGET ${_name} PROPERTY FOLDER "Tests")
     target_link_libraries(${_name}


### PR DESCRIPTION
CI fails on every branch when linking `untwine_test`, with an undefined reference
to `MakeAndRegisterTestInfo(std::string, ...)`.

As far as I can tell, the conda-forge `minizip 4.2.x` package (a transitive
dependency via PDAL, GDAL and libkml) accidentally ships googletest 1.16 headers
into `$CONDA_PREFIX/include`. Since the test build searches `${PDAL_INCLUDE_DIRS}`
before the vendored `gtest/include`, `Tests.cpp` seems to get compiled against the
1.16 headers but linked against the vendored 1.12.1 library.

This change moves the vendored include to the front of the list, so the bundled
googletest should always win no matter what the environment contains. I could
reproduce the failure locally with the leaked headers, and with the reorder in
place the build and ctest pass again. I suspect this is also why #211 is currently
red. The failure there doesn't seem to be related to that change.